### PR TITLE
Fix for latest pyyaml which requires a loader arg.

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -33,7 +33,7 @@ def make_paths(cfg):
 
 def load_config(file):
     with open(file, 'r') as stream:
-        cfg = yaml.load(stream)
+        cfg = yaml.load(stream, Loader=yaml.FullLoader)
     cfg = make_paths(cfg)
 
     return cfg


### PR DESCRIPTION
add `Loader=yaml.FullLoader` to yaml.load call to satisfy updated method signature.